### PR TITLE
Improve performance on streak and challenge services

### DIFF
--- a/services/atividades_service.py
+++ b/services/atividades_service.py
@@ -46,8 +46,15 @@ def get_streak_data(usuario):
     esperando_quebra = True
     congelado_mostrado = False
 
-    for i in range(7):
-        dia = segunda + timedelta(days=i)
+    datas_semana = [segunda + timedelta(days=i) for i in range(7)]
+    concluidas = set(
+        AtividadeConcluidas.objects.filter(
+            idusuario=usuario.idusuario,
+            dtconclusao__date__range=(segunda, segunda + timedelta(days=6))
+        ).values_list('dtconclusao__date', flat=True)
+    )
+
+    for i, dia in enumerate(datas_semana):
 
         # Dias futuros são ignorados para quebra
         if dia > hoje:
@@ -59,10 +66,7 @@ def get_streak_data(usuario):
             })
             continue
 
-        concluiu = AtividadeConcluidas.objects.filter(
-            idusuario=usuario.idusuario,
-            dtconclusao__date=dia
-        ).exists()
+        concluiu = dia in concluidas
 
         if concluiu:
             if esperando_quebra:


### PR DESCRIPTION
## Summary
- optimize `get_streak_data` to query activity completions once
- reduce per-day queries in challenge checks
- use DB filtering for active challenges and challenge lists

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: No module named 'django')*
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68404cd1effc832d86a34722ed50ee0f